### PR TITLE
[조형민] hotfix: getCompanyRank API 리턴 항목에서 myCompanyIdx삭제 #28

### DIFF
--- a/src/pages/MyComparisionResultPage.js
+++ b/src/pages/MyComparisionResultPage.js
@@ -16,12 +16,10 @@ function MyComparisionResultPage() {
   const [rankCompareCompanies, setRankCompareCompanies] = useState([]);
 
   const handleLoadCompanyRank = async orderBy => {
-    const { myCompanyIdx, rankCompanies } = await getCompanyRank(
+    const rankCompanies = await getCompanyRank(
       location.state.myCompany.id,
       orderBy,
     );
-    console.log(myCompanyIdx);
-    console.log(rankCompanies);
     setRankCompareCompanies(rankCompanies);
   };
 


### PR DESCRIPTION
백엔드에서 각 기업의 rank를 생성하여 리턴하는 것으로 변경하였으므로 삭제