### PR TITLE
[조형민] feat: 비교 결과 테이블에 정렬 기능 추가 #34

### DIFF
--- a/src/components/CompanyTableRank.js
+++ b/src/components/CompanyTableRank.js
@@ -3,7 +3,7 @@
 import './CompanyTableRank.css';
 import setCategoryEngToKor from '../utils/setCategoryEngToKor';
 
-function CompanyTableBody({ company, index, isLast, isMyCompany }) {
+function CompanyTableBody({ company, isLast, isMyCompany }) {
   const {
     name,
     imageUrl,
@@ -46,7 +46,13 @@ function CompanyTableBody({ company, index, isLast, isMyCompany }) {
   );
 }
 
-export default function CompanyTableRank({ companies, myCompanyId }) {
+export default function CompanyTableRank({
+  companies,
+  myCompanyId,
+  onEmployeeClick,
+  onRevenueClick,
+  onActInvestClick,
+}) {
   return (
     <div className="company-table-rank">
       <div className="company-table-rank-title">기업 순위 확인하기</div>
@@ -55,9 +61,15 @@ export default function CompanyTableRank({ companies, myCompanyId }) {
         <div className="header-rank-item1">기업 명</div>
         <div className="header-rank-item2">기업 소개</div>
         <div className="header-rank-item3">카테고리</div>
-        <div className="header-rank-item4">누적 투자 금액</div>
-        <div className="header-rank-item5">매출액</div>
-        <div className="header-rank-item6">고용 인원</div>
+        <div className="header-rank-item4" onClick={onActInvestClick}>
+          누적 투자 금액
+        </div>
+        <div className="header-rank-item5" onClick={onRevenueClick}>
+          매출액
+        </div>
+        <div className="header-rank-item6" onClick={onEmployeeClick}>
+          고용 인원
+        </div>
       </div>
       {companies.map((company, index) => {
         return (

--- a/src/components/CompanyTableResult.js
+++ b/src/components/CompanyTableResult.js
@@ -1,8 +1,9 @@
 // 조형민
+import { useState } from 'react';
 import setCategoryEngToKor from '../utils/setCategoryEngToKor';
 import './CompanyTableResult.css';
 
-function CompanyTableBody({ company, index, isLast, isMyCompany }) {
+function CompanyTableBody({ company, isLast, isMyCompany }) {
   const {
     name,
     imageUrl,
@@ -44,6 +45,19 @@ function CompanyTableBody({ company, index, isLast, isMyCompany }) {
 }
 
 export default function CompanyTableResult({ companies, myCompanyId }) {
+  const [order, setOrder] = useState('actualInvest');
+  const sortedCompanies = companies.sort((a, b) => b[order] - a[order]);
+
+  const handleEmployeeClick = () => {
+    setOrder('employeesCount');
+  };
+  const handleRevenueClick = () => {
+    setOrder('revenue');
+  };
+  const handleActInvestClick = () => {
+    setOrder('actualInvest');
+  };
+
   return (
     <div className="company-table">
       <div className="company-table-title">비교 결과 확인하기</div>
@@ -51,11 +65,17 @@ export default function CompanyTableResult({ companies, myCompanyId }) {
         <div className="header-item1">기업 명</div>
         <div className="header-item2">기업 소개</div>
         <div className="header-item3">카테고리</div>
-        <div className="header-item4">누적 투자 금액</div>
-        <div className="header-item5">매출액</div>
-        <div className="header-item6">고용 인원</div>
+        <div className="header-item4" onClick={handleActInvestClick}>
+          누적 투자 금액
+        </div>
+        <div className="header-item5" onClick={handleRevenueClick}>
+          매출액
+        </div>
+        <div className="header-item6" onClick={handleEmployeeClick}>
+          고용 인원
+        </div>
       </div>
-      {companies.map((company, index) => {
+      {sortedCompanies.map((company, index) => {
         return (
           <CompanyTableBody
             key={company.id}

--- a/src/pages/MyComparisionResultPage.js
+++ b/src/pages/MyComparisionResultPage.js
@@ -14,6 +14,7 @@ function MyComparisionResultPage() {
   const location = useLocation();
   const handleInvestBtnClick = () => {};
   const [rankCompareCompanies, setRankCompareCompanies] = useState([]);
+  const [order, setOrder] = useState('highestSales');
 
   const handleLoadCompanyRank = async orderBy => {
     const rankCompanies = await getCompanyRank_jhm(
@@ -22,10 +23,19 @@ function MyComparisionResultPage() {
     );
     setRankCompareCompanies(rankCompanies);
   };
+  const handleEmployeeClick = () => {
+    setOrder('mostEmployees');
+  };
+  const handleRevenueClick = () => {
+    setOrder('highestSales');
+  };
+  const handleActInvestClick = () => {
+    setOrder('highestInvestment');
+  };
 
   useEffect(() => {
-    handleLoadCompanyRank({ orderBy: 'highestSales' });
-  }, []);
+    handleLoadCompanyRank(order);
+  }, [order]);
 
   return (
     <div className="wrapper">
@@ -43,6 +53,9 @@ function MyComparisionResultPage() {
         <CompanyTableRank
           companies={rankCompareCompanies}
           myCompanyId={location.state.myCompany.id}
+          onEmployeeClick={handleEmployeeClick}
+          onRevenueClick={handleRevenueClick}
+          onActInvestClick={handleActInvestClick}
         />
         <div className="button-wrapper">
           <div className="primary-round-button" onClick={handleInvestBtnClick}>


### PR DESCRIPTION
- 테이블 헤더를 눌렀을 때 해당 항목으로 정렬되는 기능 구현
- 누적 투자 금액, 매출액, 고용 인원 기준(단, 여기서는 오름차순만 구현)
- 이후 정렬용 드롭다운 메뉴(공통)가 완성되면 정렬 기능 연결 예정