### PR TITLE
[조형민] 기업상세 페이지의 투자목록 border문제 해결, 기업 상세 이동 링크 추가

### DIFF
--- a/src/components/CompanyInvestmentSection.css
+++ b/src/components/CompanyInvestmentSection.css
@@ -43,11 +43,11 @@
 
 .table-row {
   display: flex;
-  border-bottom: 1px solid #4b4b4b;
+  border-top: 1px solid #4b4b4b;
 }
 
-.table-row:last-child {
-  border-bottom: none;
+.table-row:first-child {
+  border-top: none;
 }
 
 .table-row .table-cell {

--- a/src/components/CompanyList.js
+++ b/src/components/CompanyList.js
@@ -7,6 +7,7 @@ import convertNumTo100M from '../utils/convertNumTo100M';
 import StartupTableHead from './StartupTableHead';
 import TitleAndSearch from './TitleAndSearch';
 import Pagination from './Pagination';
+import { Link } from 'react-router-dom';
 
 function CompanyListTableBody({ company, rank }) {
   return (
@@ -14,16 +15,26 @@ function CompanyListTableBody({ company, rank }) {
       <div className="body-rank-item0">{rank}위</div>
       <div className="body-rank-item1">
         <div className="body-rank-item1-wrapper">
-          <img src={company.imageUrl} alt={company.name} className="company-table-rank-image" />
+          <img
+            src={company.imageUrl}
+            alt={company.name}
+            className="company-table-rank-image"
+          />
           <div className="company-table-rank-name">{company.name}</div>
         </div>
       </div>
       <div className="body-rank-item2">
         <div className="body-rank-item2-desc">{company.description}</div>
       </div>
-      <div className="body-rank-item3">{setCategoryEngToKor(company.category)}</div>
-      <div className="body-rank-item4">{convertNumTo100M(company.actualInvest)}억</div>
-      <div className="body-rank-item5">{convertNumTo100M(company.revenue)}억</div>
+      <div className="body-rank-item3">
+        {setCategoryEngToKor(company.category)}
+      </div>
+      <div className="body-rank-item4">
+        {convertNumTo100M(company.actualInvest)}억
+      </div>
+      <div className="body-rank-item5">
+        {convertNumTo100M(company.revenue)}억
+      </div>
       <div className="body-rank-item6">{company.employeesCount}명</div>
     </div>
   );
@@ -69,7 +80,10 @@ export default function CompanyListTableRank() {
 
   const indexOfLastCompany = currentPage * itemsPerPage;
   const indexOfFirstCompany = indexOfLastCompany - itemsPerPage;
-  const currentCompanies = sortedCompanies.slice(indexOfFirstCompany, indexOfLastCompany);
+  const currentCompanies = sortedCompanies.slice(
+    indexOfFirstCompany,
+    indexOfLastCompany
+  );
 
   const sortOptions = [
     { value: '매출액 높은 순', label: '매출액 높은 순' },
@@ -78,7 +92,6 @@ export default function CompanyListTableRank() {
     { value: '누적 투자금액 낮은 순', label: '누적 투자금액 낮은 순' },
     { value: '고용인원 높은 순', label: '고용인원 높은 순' },
     { value: '고용인원 낮은 순', label: '고용인원 낮은 순' },
-
   ];
 
   return (
@@ -86,15 +99,28 @@ export default function CompanyListTableRank() {
       <div className="title-search-dropdown">
         <TitleAndSearch keyword={keyword} setKeyword={setKeyword} />
         <Dropdown
-          options={sortOptions.map(option => option.value)}
+          options={sortOptions.map((option) => option.value)}
           selectedValue={sortOption}
           onChange={setSortOption}
         />
       </div>
       <StartupTableHead />
       {currentCompanies.map((item, index) => {
-        return <CompanyListTableBody key={item.id} company={item} rank={indexOfFirstCompany + index + 1} />;
+        return (
+          <Link
+            key={item.id}
+            to={'/companies/${item.id}'}
+            state={{ company: item }}
+          >
+            <CompanyListTableBody
+              // key={item.id}
+              company={item}
+              rank={indexOfFirstCompany + index + 1}
+            />
+          </Link>
+        );
       })}
+
       <Pagination
         currentPage={currentPage}
         onPageChange={setCurrentPage}


### PR DESCRIPTION
기업상세 페이지의 투자 목록 border문제 해결
- 문제 원인: 메뉴가 팝업되면서 last-child가 메뉴로 바뀌어서 발생
- 문제 해결: border-bottom을 border-top으로 변경하고 last-child가 아닌 first-child를 none으로

기업 상세 이동 링크 추가
- 기업 전체 목록에서 특정 기업 클릭 시 '기업 상세 페이지'로 이동
- Link to에서 state로 company를 전달